### PR TITLE
Conf properties injection for UbiRest and NfvoRest

### DIFF
--- a/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/DeviceServiceRest.java
+++ b/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/DeviceServiceRest.java
@@ -13,11 +13,13 @@ import com.ubiqube.api.entities.device.Model;
 import com.ubiqube.api.entities.device.SimpleDevice;
 import com.ubiqube.api.exception.ServiceException;
 import com.ubiqube.api.interfaces.device.DeviceService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
 public class DeviceServiceRest implements DeviceService {
 
-	private final static UbiRest rest = new UbiRest();
+	@Autowired
+	private UbiRest rest;
 
 	@Override
 	public DeviceId getDeviceId(String nsInstanceId) throws ServiceException {

--- a/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/ManufacturerModel.java
+++ b/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/ManufacturerModel.java
@@ -10,6 +10,7 @@ import com.ubiqube.api.exception.ServiceException;
 import com.ubiqube.api.interfaces.device.DeviceService;
 import com.ubiqube.etsi.mano.exception.GenericException;
 import com.ubiqube.etsi.mano.exception.NotFoundException;
+import javax.annotation.PostConstruct;
 
 /**
  *
@@ -19,10 +20,14 @@ import com.ubiqube.etsi.mano.exception.NotFoundException;
 @Service
 public class ManufacturerModel {
 	private final DeviceService deviceBean;
-	private final Map<Long, Manufacturer> manufacturers;
+	private Map<Long, Manufacturer> manufacturers;
 
 	public ManufacturerModel(DeviceService _devicebeService) {
 		deviceBean = _devicebeService;
+	}
+
+	@PostConstruct
+	private void init() {
 		try {
 			manufacturers = deviceBean.getAvailableManufacturers();
 		} catch (final ServiceException e) {

--- a/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/OrchestrationServiceRest.java
+++ b/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/OrchestrationServiceRest.java
@@ -9,15 +9,13 @@ import org.springframework.stereotype.Service;
 import com.ubiqube.api.entities.orchestration.ProcessInstance;
 import com.ubiqube.api.exception.ServiceException;
 import com.ubiqube.api.interfaces.orchestration.OrchestrationService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
 public class OrchestrationServiceRest implements OrchestrationService {
 
-	private final UbiRest rest;
-
-	public OrchestrationServiceRest(final UbiRest _rest) {
-		this.rest = _rest;
-	}
+	@Autowired
+	private UbiRest rest;
 
 	@Override
 	public ProcessInstance scheduleServiceImmediateMode(final String ubiqubeId, final long serviceId, final String serviceName, final String processName, final Map<String, String> varsMap) throws ServiceException {

--- a/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/RepositoryServiceRest.java
+++ b/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/RepositoryServiceRest.java
@@ -9,14 +9,13 @@ import org.springframework.stereotype.Service;
 import com.ubiqube.api.entities.repository.RepositoryElement;
 import com.ubiqube.api.exception.ServiceException;
 import com.ubiqube.api.interfaces.repository.RepositoryService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
 public class RepositoryServiceRest implements RepositoryService {
-	private final UbiRest rest;
 
-	public RepositoryServiceRest(final UbiRest _ubiRest) {
-		rest = _ubiRest;
-	}
+	@Autowired
+	private UbiRest rest;
 
 	@Override
 	public RepositoryElement getElement(final String path) {

--- a/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/UbiRest.java
+++ b/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/UbiRest.java
@@ -9,10 +9,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.beans.factory.annotation.Value;
+
 
 @Service
 public class UbiRest {
-	private final static String URL = "http://localhost:8181/ubi-api-rest";
+
+	@Value("${msa.rest-api.url}")
+	private String URL;
 
 	private final RestTemplate restTemplate;
 

--- a/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/UbiRest.java
+++ b/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/UbiRest.java
@@ -10,9 +10,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 
 
 @Service
+@PropertySource("classpath:ubi-mano.properties")
 public class UbiRest {
 
 	@Value("${msa.rest-api.url}")

--- a/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/rest/NfvoRest.java
+++ b/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/rest/NfvoRest.java
@@ -6,8 +6,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import org.springframework.beans.factory.annotation.Value;
+import javax.annotation.PostConstruct;
 
-import com.ubiqube.etsi.mano.service.Configuration;
 
 @Service
 public class NfvoRest extends AbstractRest {
@@ -15,7 +15,8 @@ public class NfvoRest extends AbstractRest {
 	@Value("${nfvo.url}")
 	private String url;
 
-	public NfvoRest(final Configuration _conf) {
+	@PostConstruct
+	private void checkConfig() {
 		Assert.notNull(url, "nfvo.url is not declared in property file.");
 	}
 

--- a/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/rest/NfvoRest.java
+++ b/MANO-API/src/main/java/com/ubiqube/etsi/mano/service/rest/NfvoRest.java
@@ -5,15 +5,17 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import org.springframework.beans.factory.annotation.Value;
 
 import com.ubiqube.etsi.mano.service.Configuration;
 
 @Service
 public class NfvoRest extends AbstractRest {
-	private final String url;
+
+	@Value("${nfvo.url}")
+	private String url;
 
 	public NfvoRest(final Configuration _conf) {
-		url = _conf.get("nfvo.url");
 		Assert.notNull(url, "nfvo.url is not declared in property file.");
 	}
 

--- a/MANO-API/src/main/resources/ubi-mano.properties
+++ b/MANO-API/src/main/resources/ubi-mano.properties
@@ -1,0 +1,2 @@
+msa.rest-api.url = http://msa/ubi-api-rest
+nfvo.url = http://msa/


### PR DESCRIPTION
externalize configuration to `ubi-mano.properties` for:
- `msa.rest-api.url`
- `nfvo.url`

Property `msa.rest-api.url` is set to `http://msa/ubi-api-rest` i.e. points to the msa container.
For a local dev setup, change the value to use e.g. `localhost` instead.